### PR TITLE
Fix helm upgrade issue

### DIFF
--- a/openshift-api-group/Chart.yaml
+++ b/openshift-api-group/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: openshift-api-group
-version: 0.1.1
+version: 0.1.2

--- a/openshift-api-group/templates/deploymentconfig.yaml
+++ b/openshift-api-group/templates/deploymentconfig.yaml
@@ -19,6 +19,9 @@ spec:
       serviceAccountName: tiller
       containers:
       - name: openshift-api-group
+        {{- if .Values.image }}
+        image: {{ .Values.image }}
+        {{- end }}
         ports:
         - containerPort: 8080
           name: web

--- a/openshift-api-group/values.yaml
+++ b/openshift-api-group/values.yaml
@@ -3,5 +3,7 @@ createUsersRole: false
 # Make the tiller service account a cluster admin
 clusterAdmin: false
 namespace: kube-system
+# `helm upgrade` will cause deployments to silently fail if "image" is not provided
+image:
 version: v0.1.0
 tillerVersion: v2.5.1


### PR DESCRIPTION
This PR adds an optional `image` value, which allows chart users to get around an issue with `helm upgrade` when `spec.template.spec.containers[0].image` is not provided.