### PR TITLE
fix: Use public repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.8.1
 
-WORKDIR $GOPATH/src/github.com/megalord/openshift-api-group/
+WORKDIR $GOPATH/src/github.com/player-two/openshift-api-group/
 COPY glide.yaml glide.lock ./
 RUN go get -u github.com/Masterminds/glide && \
     glide install --strip-vendor

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/megalord/openshift-api-group
+package: github.com/player-two/openshift-api-group
 import:
 - package: k8s.io/apimachinery
   version: release-1.6

--- a/openshift-api-group/templates/buildconfig.yaml
+++ b/openshift-api-group/templates/buildconfig.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     type: Git
     git:
-      uri: https://github.com/megalord/openshift-api-group.git
+      uri: https://github.com/player-two/openshift-api-group.git
       ref: {{ .Values.version }}
   strategy:
     type: Docker


### PR DESCRIPTION
This PR replaces references to `megalord` with `player-two`.